### PR TITLE
Didn't work out of the box on my system: header fields should be case-insensitive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want usage detail, type `--help`.
 ```
 
 When standalone, build php version is system default.
-If you want use other php version, you can change `phpize` and `php-config` command by parameter.
+If you want to use another php version, you can change `phpize` and `php-config` command by parameter.
 
 ```
 $ bin/pecl-build <package_naem> -p /path/to/phpize -i /path/to/php-config
@@ -22,12 +22,12 @@ $ bin/pecl-build <package_naem> -p /path/to/phpize -i /path/to/php-config
 ### Use phpenv plugins
 
 ```
-% git clone https://github.com/crocos/pecl-build.git $PHPENV_ROOT/plugins/pecl-build
+% git clone https://github.com/berenddeboer/pecl-build.git $PHPENV_ROOT/plugins/pecl-build
 % phpenv pecl <package_name>
 ```
 
-phpenv plugin follow php version for phpenv specified.
-If you want specify build php version, you can set parameter.
+phpenv plugin follows the php version installed by phpenv.
+If you want to build for a specific php version, you can specify a parameter.
 
 ```
 % phpenv pecl <package_name> -j <php version>
@@ -53,4 +53,3 @@ so created `.ini` config set `zend_extension`
 * Initial Version
 
 AUTHOR:: Daichi Kamemoto <yudoufu@crocos.co.jp>
-

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ install_pecl apcu
 
 ## ChangeLog
 
+### v0.2 2025/07/28
+
+Fix pecl url as https is now required.
+
 ### v0.1.1 2025/07/28
 
 Update docs.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you want usage detail, type `--help`.
 ### Use standalone
 
 ```
-% git clone https://github.com/crocos/pecl-build.git
+% git clone https://github.com/berenddeboer/pecl-build.git
 % cd pecl-build
 % bin/pecl-build <package_name>
 ```
@@ -19,19 +19,19 @@ If you want to use another php version, you can change `phpize` and `php-config`
 $ bin/pecl-build <package_naem> -p /path/to/phpize -i /path/to/php-config
 ```
 
-### Use phpenv plugins
+### Install as phpenv plugins
 
 ```
-% git clone https://github.com/berenddeboer/pecl-build.git $PHPENV_ROOT/plugins/pecl-build
-% phpenv pecl <package_name>
+% git clone https://github.com/berenddeboer/pecl-build.git $(phpenv root)/plugins/pecl-build
+phpenv pecl <package_name>
 ```
 
 phpenv plugin follows the php version installed by phpenv.
 If you want to build for a specific php version, you can specify a parameter.
 
-```
-% phpenv pecl <package_name> -j <php version>
-% phpenv pecl <package_name> -a # build all php version by phpenv have.
+```sh
+phpenv pecl <package_name> -j <php version>
+phpenv pecl <package_name> -a # build all php version by phpenv have.
 ```
 
 *NOTICE: phpenv plugin versin is now skipped `system` environment build.*
@@ -39,14 +39,50 @@ If you want to build for a specific php version, you can specify a parameter.
 you want specify package version:
 
 ```
-% phpenv pecl <package_name>-<package_version>
+phpenv pecl <package_name>-<package_version>
 ```
 
 and when you build `zend_extension`, pass `-z (--zend-extension)` option.
 so created `.ini` config set `zend_extension`
 
+### Integrate with php-build
+
+Patch the php-build script to add this:
+
+```sh
+# ### install_pecl
+
+# install pecl (requires pecl-build)
+install_pecl() {
+    local name=$1
+    log "Pecl" "Installing: $name"
+    echo phpenv pecl $name -j $DEFINITION
+    phpenv pecl $name -j $DEFINITION > /dev/null
+}
+```
+
+You can then add `install_pecl` to build files like 8.3.23:
+
+```
+configure_option "--enable-gd"
+configure_option "--with-jpeg"
+configure_option "--with-zip"
+configure_option "--with-mhash"
+
+configure_option -D "--with-xmlrpc"
+
+install_package "https://www.php.net/distributions/php-8.3.23.tar.bz2"
+install_xdebug "3.4.5"
+enable_builtin_opcache
+install_pecl redis
+install_pecl apcu
+```
 
 ## ChangeLog
+
+### v0.1.1 2025/07/28
+
+Update docs.
 
 ### v0.1.0 2013/12/06
 

--- a/bin/pecl-build
+++ b/bin/pecl-build
@@ -17,7 +17,7 @@ usage() {
     echo "  --dry                   dry run mode."
     echo "  -d, --base-dir          specified build directory.      (default: /tmp/pecl-build)"
     echo "  -p, --phpize            absolute path for phpize.       (default: environment dependent)"
-    echo "  -i, --php-config        aboslute path for php-config.   (default: environment dependent)"
+    echo "  -i, --php-config        absolute path for php-config.   (default: environment dependent)"
     echo "  -c, --configure-options additional configure options.   (default: nothing)"
     echo "  -z, --zend-extension    registerd zend_extensin at ini file generated."
     echo "  --skip-test             skip make test."
@@ -57,13 +57,13 @@ main() {
     debug "install package: $(green $package)"
 
     # extension build base dir
-    if [ "x$base_dir" = "x" ];then
+    if [ -z $base_dir ];then
         base_dir=/tmp/pecl-build
     fi
     debug "base_dir: $(green $base_dir)"
 
     # phpize command path
-    if [ "x$phpize" = "x" ];then
+    if [ -z $phpize ];then
         phpize=phpize
     else
         phpize=$(echo $phpize) # path expantion
@@ -75,12 +75,12 @@ main() {
     debug "phpize command: $(green $phpize)"
 
     # additional configure options
-    if [ "x$configure_options" = "x" ];then
+    if [ -z $configure_options ];then
         configure_options=
     fi
 
     # php-config command path
-    if [ "x$phpconfig" = "x" ];then
+    if [ -z $phpconfig ];then
         phpconfig=php-config
     else
         phpconfig=$(echo $phpconfig) #path expantion
@@ -96,11 +96,11 @@ main() {
 
     ### main ###
 
-    # crete build base
+    # create build base
     pecl_url=http://pecl.php.net/get
     url=$pecl_url/$package
 
-    tarball=$(curl -I $url 2>/dev/null |grep Content-disposition |cut -d'=' -f2 |tr -d \")
+    tarball=$(curl -I $url 2>/dev/null |grep -i Content-disposition |cut -d'=' -f2 |tr -d \")
     package_name=${tarball%.*}
     extension=${package_name%-*}
     version=${package_name##*-}
@@ -113,10 +113,10 @@ main() {
     debug "version: $(green $version)"
     debug "build_dir: $(green $build_dir)"
 
-    info "create build directory: $(green $build_dir)"
+    info "creating build directory: $(green $build_dir)"
     run mkdir -p $build_dir
     if [ -e "$build_dir/$package_name" ];then
-        warn "already exist old dir. remove it."
+        warn "removing exist old dir $build_dir/$package_name."
         run rm -rf $build_dir/$package_name
     fi
 
@@ -208,4 +208,3 @@ debug() {
 
 # call main.
 main "$@"
-

--- a/bin/pecl-build
+++ b/bin/pecl-build
@@ -97,7 +97,7 @@ main() {
     ### main ###
 
     # create build base
-    pecl_url=http://pecl.php.net/get
+    pecl_url=https://pecl.php.net/get
     url=$pecl_url/$package
 
     tarball=$(curl -I $url 2>/dev/null |grep -i Content-disposition |cut -d'=' -f2 |tr -d \")
@@ -116,7 +116,7 @@ main() {
     info "creating build directory: $(green $build_dir)"
     run mkdir -p $build_dir
     if [ -e "$build_dir/$package_name" ];then
-        warn "removing exist old dir $build_dir/$package_name."
+        warn "removing existing old dir $build_dir/$package_name."
         run rm -rf $build_dir/$package_name
     fi
 
@@ -132,7 +132,7 @@ main() {
     run ./configure $configure_options
     run make
     if [ $is_skip_test ];then
-        warn "skip test mode. not run 'make test'"
+        warn "Skipping test mode. not running 'make test'"
     else
         run make test
     fi

--- a/bin/phpenv-pecl
+++ b/bin/phpenv-pecl
@@ -89,7 +89,7 @@ _build_extension() {
         fi
 
         info "build $(green $package) on php-$(green $version)"
-        run pecl-build $package -p $php_dir/bin/phpize -i $php_dir/bin/php-config $options
+        run pecl-build $package -p $php_dir/bin/phpize -i $php_dir/bin/php-config --skip-test $options
     fi
 }
 
@@ -145,4 +145,3 @@ debug() {
 
 # call main.
 main "$@"
-


### PR DESCRIPTION
I always got:

```
tar: /tmp/pecl-build: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

Fixed some typos as well.
