### PR TITLE
Fix tarball retrieving

### DIFF
--- a/bin/pecl-build
+++ b/bin/pecl-build
@@ -100,7 +100,7 @@ main() {
     pecl_url=http://pecl.php.net/get
     url=$pecl_url/$package
 
-    tarball=$(curl -I $url 2>/dev/null |grep Content-disposition |cut -d'=' -f2 |tr -d \")
+    tarball=$(curl -I $url 2>/dev/null |grep -i Content-disposition |cut -d'=' -f2 |tr -d \")
     package_name=${tarball%.*}
     extension=${package_name%-*}
     version=${package_name##*-}


### PR DESCRIPTION
Look for the `Content-Disposition` directive in the response header in a case insensitive manner.

Signed-off-by: Eric Villard <dev@eviweb.fr>