### PR TITLE
Ignore case when detecting content disposition header value

### DIFF
--- a/bin/pecl-build
+++ b/bin/pecl-build
@@ -100,7 +100,7 @@ main() {
     pecl_url=http://pecl.php.net/get
     url=$pecl_url/$package
 
-    tarball=$(curl -I $url 2>/dev/null |grep Content-disposition |cut -d'=' -f2 |tr -d \")
+    tarball=$(curl -I $url 2>/dev/null |grep -i Content-disposition |cut -d'=' -f2 |tr -d \")
     package_name=${tarball%.*}
     extension=${package_name%-*}
     version=${package_name##*-}


### PR DESCRIPTION
At some point the header keys returned from pecl have become lower case. This PR adds case insensitivity to the header check.