### PR TITLE
fix: tar: /tmp/pecl-build: Cannot open: No such file or directory

### DIFF
--- a/bin/pecl-build
+++ b/bin/pecl-build
@@ -96,11 +96,11 @@ main() {
 
     ### main ###
 
-    # crete build base
+    # create build base
     pecl_url=http://pecl.php.net/get
     url=$pecl_url/$package
 
-    tarball=$(curl -I $url 2>/dev/null |grep Content-disposition |cut -d'=' -f2 |tr -d \")
+    tarball=$(curl -I $url 2>/dev/null |grep -i Content-disposition |cut -d'=' -f2 |tr -d \")
     package_name=${tarball%.*}
     extension=${package_name%-*}
     version=${package_name##*-}


### PR DESCRIPTION
Modify the regular expression to obtain the `Content-Disposition` of the curl response header:
```
$ curl -I http://pecl.php.net/get/apcu-4.0.2
HTTP/1.1 200 OK
Date: Mon, 09 Jun 2025 07:26:35 GMT
Server: Apache/2.4.62 (Debian)
Set-Cookie: PHPSESSID=0f68sd7edbltp6u8rlgdeiktg1; path=/
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate
Pragma: no-cache
Content-Disposition: attachment;filename=apcu-4.0.2.tgz
Strict-Transport-Security: max-age=31536000
Last-Modified: Mon, 30 Mar 2015 07:05:41 GMT
ETag: "1d605-610ccb7d2fe2a"
Content-Length: 120325
Content-Type: application/octet-stream
```

error:
```
$ ./bin/pecl-build -v apcu-4.0.2
[debug] install package: apcu-4.0.2
[debug] base_dir: /tmp/pecl-build
[debug] phpize command: phpize
[debug] php-config command: php-config
[debug] additional configure options: 
[debug] url: http://pecl.php.net/get/apcu-4.0.2
[debug] tarball: 
[debug] package_name: 
[debug] extension: 
[debug] version: 
[debug] build_dir: /tmp/pecl-build/
[info] create build directory: /tmp/pecl-build/
[run] mkdir -p /tmp/pecl-build/
[warn] already exist old dir. remove it.
[run] rm -rf /tmp/pecl-build//
[info] fetch package: http://pecl.php.net/get/apcu-4.0.2
[run] curl http://pecl.php.net/get/apcu-4.0.2 | tar xzf - -C /tmp/pecl-build/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  117k  100  117k    0     0  95018      0  0:00:01  0:00:01 --:--:-- 95043
tar: /tmp/pecl-build: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```
